### PR TITLE
Redundant use of infrastructure-only property.

### DIFF
--- a/CPPCheckPlugin/CPPCheckPluginPackage.cs
+++ b/CPPCheckPlugin/CPPCheckPluginPackage.cs
@@ -42,7 +42,7 @@ namespace VSPackage.CPPCheckPlugin
 			_eventsHandlers = _dte.Events.DocumentEvents;
 			_eventsHandlers.DocumentSaved += documentSaved;
 
-			OutputWindow outputWindow = (OutputWindow)_dte.Application.Windows.Item(EnvDTE.Constants.vsWindowKindOutput).Object;
+			OutputWindow outputWindow = (OutputWindow)_dte.Windows.Item(EnvDTE.Constants.vsWindowKindOutput).Object;
 			_outputWindow = outputWindow.OutputWindowPanes.Add("Code analysis output");
 
 			_analyzers.Add(new AnalyzerCppcheck());


### PR DESCRIPTION
MSDN says http://msdn.microsoft.com/en-us/library/vstudio/envdte._dte.application%28v=vs.100%29.aspx DTE.Application is not for use by user code. Plus it yields the same DTE anyway.
