### PR TITLE
Bring output window to front upon analysis completion

### DIFF
--- a/CPPCheckPlugin/AnalyzerCppcheck.cs
+++ b/CPPCheckPlugin/AnalyzerCppcheck.cs
@@ -10,7 +10,8 @@ namespace VSPackage.CPPCheckPlugin
 {
 	class AnalyzerCppcheck : ICodeAnalyzer
 	{
-		public override void analyze(List<SourceFile> filesToAnalyze, OutputWindowPane outputWindow, bool is64bitConfiguration, bool isDebugConfiguration)
+		public override void analyze(List<SourceFile> filesToAnalyze, OutputWindowPane outputWindow, bool is64bitConfiguration,
+			bool isDebugConfiguration, bool bringOutputToFrontAfterAnalysis)
 		{
 			Debug.Assert(_numCores > 0);
 			String cppheckargs = Properties.Settings.Default.DefaultArguments;
@@ -107,7 +108,7 @@ namespace VSPackage.CPPCheckPlugin
 
 			Properties.Settings.Default["CPPcheckPath"] = analyzerPath;
 			Properties.Settings.Default.Save();
-			run(analyzerPath, cppheckargs, outputWindow);
+			run(analyzerPath, cppheckargs, outputWindow, bringOutputToFrontAfterAnalysis);
 		}
 
 		protected override HashSet<string> readSuppressions(string projectBasePath)

--- a/CPPCheckPlugin/CPPCheckPluginPackage.cs
+++ b/CPPCheckPlugin/CPPCheckPluginPackage.cs
@@ -87,16 +87,12 @@ namespace VSPackage.CPPCheckPlugin
 			try
 			{
 				VCProject project = (VCProject)document.ProjectItem.ContainingProject.Object;
-				String currentConfigName = document.ProjectItem.ConfigurationManager.ActiveConfiguration.ConfigurationName;
-				SourceFile sourceForAnalysis = createSourceFile(document.FullName, currentConfigName, project);
+				var currentConfig = document.ProjectItem.ConfigurationManager.ActiveConfiguration;
+				SourceFile sourceForAnalysis = createSourceFile(document.FullName, currentConfig, project);
 				if (sourceForAnalysis == null)
 					return;
 
-				_outputWindow.Clear();
-				foreach (var analyzer in _analyzers)
-				{
-					analyzer.analyze(sourceForAnalysis, _outputWindow, currentConfigName.Contains("64"), currentConfigName.ToLower().Contains("debug"));
-				}
+				runAnalysis(sourceForAnalysis, currentConfig, false);
 			}
 			catch (System.Exception ex)
 			{
@@ -118,7 +114,7 @@ namespace VSPackage.CPPCheckPlugin
 				return;
 			}
 
-			String currentConfigName = _dte.Solution.Projects.Item(1).ConfigurationManager.ActiveConfiguration.ConfigurationName;
+			var currentConfig = _dte.Solution.Projects.Item(1).ConfigurationManager.ActiveConfiguration;
 			List<SourceFile> files = new List<SourceFile>();
 			foreach (dynamic o in activeProjects)
 			{
@@ -135,7 +131,7 @@ namespace VSPackage.CPPCheckPlugin
 					{
 						if (!(file.Name.StartsWith("moc_") && file.Name.EndsWith(".cpp")) && !(file.Name.StartsWith("ui_") && file.Name.EndsWith(".h")) && !(file.Name.StartsWith("qrc_") && file.Name.EndsWith(".cpp"))) // Ignoring Qt MOC and UI files
 						{
-							SourceFile f = createSourceFile(file.FullPath, currentConfigName, project);
+							SourceFile f = createSourceFile(file.FullPath, currentConfig, project);
 							if (f != null)
 								files.Add(f);
 						}
@@ -144,20 +140,34 @@ namespace VSPackage.CPPCheckPlugin
 				break; // Only checking one project at a time for now
 			}
 
+			runAnalysis(files, currentConfig, true);
+		}
+
+		private void runAnalysis(SourceFile file, Configuration currentConfig, bool bringOutputToFrontAfterAnalysis)
+		{
+			var list = new List<SourceFile>();
+			list.Add(file);
+			runAnalysis(list, currentConfig, bringOutputToFrontAfterAnalysis);
+		}
+
+		private void runAnalysis(List<SourceFile> files, Configuration currentConfig, bool bringOutputToFrontAfterAnalysis)
+		{
 			_outputWindow.Clear();
+			var currentConfigName = currentConfig.ConfigurationName;
 			foreach (var analyzer in _analyzers)
 			{
-				analyzer.analyze(files, _outputWindow, currentConfigName.Contains("64"), currentConfigName.ToLower().Contains("debug"));
+				analyzer.analyze(files, _outputWindow, currentConfigName.Contains("64"), currentConfigName.ToLower().Contains("debug"), bringOutputToFrontAfterAnalysis);
 			}
 		}
 
-		SourceFile createSourceFile(string filePath, string configurationName, VCProject project)
+		SourceFile createSourceFile(string filePath, Configuration targetConfig, VCProject project)
 		{
 			try
 			{
+				var configurationName = targetConfig.ConfigurationName;
 				VCConfiguration config = project.Configurations.Item(configurationName);
-				IVCCollection toolsCollection = config.Tools;
 				SourceFile sourceForAnalysis = new SourceFile(filePath, project.ProjectDirectory.Replace(@"""", ""));
+				IVCCollection toolsCollection = config.Tools;
 				foreach (var tool in toolsCollection)
 				{
 					// Project-specific includes

--- a/CPPCheckPlugin/ICodeAnalyzer.cs
+++ b/CPPCheckPlugin/ICodeAnalyzer.cs
@@ -15,18 +15,12 @@ namespace VSPackage.CPPCheckPlugin
 			_numCores = Environment.ProcessorCount;
 		}
 
-		public abstract void analyze(List<SourceFile> filesToAnalyze, OutputWindowPane outputWindow, bool is64bitConfiguration, bool isDebugConfiguration);
-
-		public void analyze(SourceFile fileToAnalyze, OutputWindowPane outputWindow, bool is64bitConfiguration, bool isDebugConfiguration)
-		{
-			List<SourceFile> list = new List<SourceFile>();
-			list.Add(fileToAnalyze);
-			analyze(list, outputWindow, is64bitConfiguration, isDebugConfiguration);
-		}
+		public abstract void analyze(List<SourceFile> filesToAnalyze, OutputWindowPane outputWindow, bool is64bitConfiguration,
+			bool isDebugConfiguration, bool bringOutputToFrontAfterAnalysis);
 
 		protected abstract HashSet<string> readSuppressions(string projectBasePath);
 
-		protected void run(string analyzerExePath, string arguments, OutputWindowPane outputWindow)
+		protected void run(string analyzerExePath, string arguments, OutputWindowPane outputWindow, bool bringOutputToFrontAfterAnalysis)
 		{
 			_outputWindow = outputWindow;
 			try
@@ -37,12 +31,12 @@ namespace VSPackage.CPPCheckPlugin
 			catch (System.Exception /*ex*/) {}
 
 			_process = new System.Diagnostics.Process(); // Reusing the same process instance seems to not be possible because of BeginOutputReadLine and BeginErrorReadLine
-			_thread = new System.Threading.Thread(() => analyzerThreadFunc(analyzerExePath, arguments));
+			_thread = new System.Threading.Thread(() => analyzerThreadFunc(analyzerExePath, arguments, bringOutputToFrontAfterAnalysis));
 			_thread.Name = "cppcheck";
 			_thread.Start();
 		}
 
-		private void analyzerThreadFunc(string analyzerExePath, string arguments)
+		private void analyzerThreadFunc(string analyzerExePath, string arguments, bool bringOutputToFrontAfterAnalysis)
 		{
 			try
 			{
@@ -78,7 +72,12 @@ namespace VSPackage.CPPCheckPlugin
 				else
 					_outputWindow.OutputString("Analysis completed in " + timeElapsed.ToString() + " seconds\n");
 				_process.Close();
-
+				if (bringOutputToFrontAfterAnalysis)
+				{
+					Window outputWindow = _outputWindow.DTE.Windows.Item(EnvDTE.Constants.vsWindowKindOutput);
+					outputWindow.Visible = true;
+					_outputWindow.Activate();
+				}
 			} catch (System.Exception /*ex*/) {
 				
 			}


### PR DESCRIPTION
This addresses the following problems:
1. exception if a non-C++ project check is attempted - a neat message is output instead
2. code duplication
3. if the output window is not brought to front the analysis output is not visible - now in cases when analysis is run from menu (not on saving documents because that would likely be annoying) the output window is brought to front.
