### PR TITLE
Reorder attributes in unform fashion.

### DIFF
--- a/CPPCheckPlugin/source.extension.vsixmanifest
+++ b/CPPCheckPlugin/source.extension.vsixmanifest
@@ -8,8 +8,8 @@
   </Metadata>
   <Installation InstalledByMsi="false">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,12.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Premium" Version="[11.0,12.0]" />
     <InstallationTarget Id="Microsoft.VisualStudio.Ultimate" Version="[11.0,12.0]" />
-    <InstallationTarget Version="[11.0,12.0]" Id="Microsoft.VisualStudio.Premium" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />


### PR DESCRIPTION
The manifest has inconsistent ordering of attributes for different VS versions which has no use and requires extra brain effort.
