### PR TITLE
Use dynamics to avoid binding to specific version interfaces.

### DIFF
--- a/CPPCheckPlugin/CPPCheckPlugin.csproj
+++ b/CPPCheckPlugin/CPPCheckPlugin.csproj
@@ -57,14 +57,6 @@
     <Reference Include="Microsoft.VisualStudio.Shell.11.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
-    <Reference Include="Microsoft.VisualStudio.VCProject, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <SpecificVersion>False</SpecificVersion>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <SpecificVersion>False</SpecificVersion>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
This pretty much gets rid of Microsoft.VisualStudio.VCProjectEngine static dependencies which resolves the following problem (reported here https://github.com/VioletGiraffe/cppcheck-vs-addin/issues/10#issuecomment-34039855 )

> I can't make the same package work for both VS2012 and 2013 (2010 is out of the question for now, there's a problem with manifest file for it). I've just built the project from repository (which is for VS2012) in 2013, and installed the package into both VS2012 and 2013. As soon as I save a file in 2013 I get a message: "Exception occurred in cppcheck add-in: Unable to cast object of type 'Microsoft.VisualStudio.Project.VisualC.VCProjectEngine.VCProjectShim' to type 'Microsoft.VisualStudio.VCProjectEngine.VCProject'."
> This is beause the project is importing v11.0 assemblies, and VS2012 uses v12.0.
