### PR TITLE
Detect the moment when Visual Studio is shutting down and stop cppcheck.exe

### DIFF
--- a/CPPCheckPlugin/AnalyzerCppcheck.cs
+++ b/CPPCheckPlugin/AnalyzerCppcheck.cs
@@ -168,10 +168,5 @@ namespace VSPackage.CPPCheckPlugin
 
 			return suppressions;
 		}
-
-		protected virtual void Dispose(bool disposing)
-		{
-			base.Dispose(disposing);
-		}
 	}
 }

--- a/CPPCheckPlugin/CPPCheckPluginPackage.cs
+++ b/CPPCheckPlugin/CPPCheckPluginPackage.cs
@@ -62,6 +62,19 @@ namespace VSPackage.CPPCheckPlugin
 				mcs.AddCommand(menuSettings);
 			}
 		}
+
+		protected override int QueryClose(out bool canClose)
+		{
+			int result = base.QueryClose(out canClose);
+			if (canClose)
+			{
+				foreach (var item in _analyzers)
+				{
+					item.Dispose();
+				}
+			}
+			return result;
+		}
 		#endregion
 
 		private void onCheckCurrentProjectRequested(object sender, EventArgs e)


### PR DESCRIPTION
This fixes https://github.com/VioletGiraffe/cppcheck-vs-addin/issues/14 further - otherwise I still get the output callback invoked when the environment is no longer ready to accept it. I also removed the completely useless `Dispose()` implementation which was hiding the parent implementation and would never be called anyway.
