### PR TITLE
fix default settings (remove "error" severity)

### DIFF
--- a/CPPCheckPlugin/Properties/Settings.settings
+++ b/CPPCheckPlugin/Properties/Settings.settings
@@ -18,7 +18,7 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="SeveritiesString" Type="System.String" Scope="User">
-      <Value Profile="(Default)">style,information,warning,performance,portability,error</Value>
+      <Value Profile="(Default)">style,information,warning,performance,portability</Value>
     </Setting>
     <Setting Name="SuppressionsString" Type="System.String" Scope="User">
       <Value Profile="(Default)">passedByValue,cstyleCast,missingIncludeSystem,unusedStructMember,unmatchedSuppression,class_X_Y,missingInclude,constStatement,unusedPrivateFunction</Value>


### PR DESCRIPTION
fix #37 remove "error" from default severities list
