### PR TITLE
Cleaning up enum handling - default should be throwing exception instead of doing nothing

### DIFF
--- a/CPPCheckPlugin/AnalyzerCppcheck.cs
+++ b/CPPCheckPlugin/AnalyzerCppcheck.cs
@@ -183,21 +183,23 @@ namespace VSPackage.CPPCheckPlugin
 			String suppressionLine = null;
 			switch (scope)
 			{
-			case ICodeAnalyzer.SuppressionScope.suppressAllMessagesThisFile:
-				suppressionLine = "*:" + p.FileName;
-				break;
-			case ICodeAnalyzer.SuppressionScope.suppressThisMessageFileLine:
-				suppressionLine = p.MessageId + ":" + p.FileName + ":" + p.Line;
-				break;
-			case ICodeAnalyzer.SuppressionScope.suppressThisMessageFileOnly:
-				suppressionLine = p.MessageId + ":" + p.FileName;
-				break;
-			case ICodeAnalyzer.SuppressionScope.suppressThisMessageGlobally:
-				suppressionLine = p.MessageId; // TODO:
-				break;
-			case ICodeAnalyzer.SuppressionScope.suppressThisMessageProjectOnly:
-				suppressionLine = p.MessageId;
-				break;
+				case ICodeAnalyzer.SuppressionScope.suppressAllMessagesThisFile:
+					suppressionLine = "*:" + p.FileName;
+					break;
+				case ICodeAnalyzer.SuppressionScope.suppressThisMessageFileLine:
+					suppressionLine = p.MessageId + ":" + p.FileName + ":" + p.Line;
+					break;
+				case ICodeAnalyzer.SuppressionScope.suppressThisMessageFileOnly:
+					suppressionLine = p.MessageId + ":" + p.FileName;
+					break;
+				case ICodeAnalyzer.SuppressionScope.suppressThisMessageGlobally:
+					suppressionLine = p.MessageId; // TODO:
+					break;
+				case ICodeAnalyzer.SuppressionScope.suppressThisMessageProjectOnly:
+					suppressionLine = p.MessageId;
+					break;
+				default:
+					throw new InvalidOperationException("Unsupported value: " + scope.ToString());
 			}
 
 			String suppresionsFilePath = p.BaseProjectPath + "\\suppressions.cfg";

--- a/CPPCheckPlugin/ICodeAnalyzer.cs
+++ b/CPPCheckPlugin/ICodeAnalyzer.cs
@@ -7,7 +7,14 @@ namespace VSPackage.CPPCheckPlugin
 {
 	public abstract class ICodeAnalyzer : IDisposable
 	{
-		public enum SuppressionScope { suppressThisMessageGlobally, suppressThisMessageProjectOnly, suppressThisMessageFileOnly, suppressThisMessageFileLine, suppressAllMessagesThisFile };
+		public enum SuppressionScope
+		{
+			suppressThisMessageGlobally,
+			suppressThisMessageProjectOnly,
+			suppressThisMessageFileOnly,
+			suppressThisMessageFileLine,
+			suppressAllMessagesThisFile
+		};
 		public enum AnalysisType { DocumentSavedAnalysis, ProjectAnalysis };
 
 		protected ICodeAnalyzer()

--- a/CPPCheckPlugin/MainToolWindowUI.xaml.cs
+++ b/CPPCheckPlugin/MainToolWindowUI.xaml.cs
@@ -144,8 +144,7 @@ namespace VSPackage.CPPCheckPlugin
 							bitmap = new System.Drawing.Icon(SystemIcons.Error, SystemIcons.Error.Height, SystemIcons.Error.Width).ToBitmap();
 							break;
 						default:
-							bitmap = new System.Drawing.Icon(SystemIcons.Information, SystemIcons.Information.Height, SystemIcons.Information.Width).ToBitmap();
-							break;
+							throw new InvalidOperationException("Unsupported value: " + _problem.Severity.ToString());
 					}
 					ImageSource imgSource = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(bitmap.GetHbitmap(), IntPtr.Zero, System.Windows.Int32Rect.Empty, BitmapSizeOptions.FromWidthAndHeight(bitmap.Width, bitmap.Height));
 					return imgSource;

--- a/CPPCheckPlugin/Problem.cs
+++ b/CPPCheckPlugin/Problem.cs
@@ -8,7 +8,12 @@ namespace VSPackage.CPPCheckPlugin
 {
 	public class Problem
 	{
-		public enum SeverityLevel { info, warning, error };
+		public enum SeverityLevel
+		{
+			info,
+			warning,
+			error
+		};
 
 		public Problem(ICodeAnalyzer analyzer, SeverityLevel severity, String messageId, String message, String file, int line, String baseProjectPath)
 		{


### PR DESCRIPTION
This cleans up enum handling:
- all-in-one-line declarations
- doing nothing when an unhandled enum value is encountered
- inconsistent indenting
