### PR TITLE
Cleanup enum handling and code duplication.

### DIFF
--- a/CPPCheckPlugin/AnalyzerCppcheck.cs
+++ b/CPPCheckPlugin/AnalyzerCppcheck.cs
@@ -185,21 +185,23 @@ namespace VSPackage.CPPCheckPlugin
 			String suppressionLine = null;
 			switch (scope)
 			{
-			case ICodeAnalyzer.SuppressionScope.suppressAllMessagesThisFile:
+				case ICodeAnalyzer.SuppressionScope.suppressAllMessagesThisFile:
 					suppressionLine = "*:" + simpleFileName;
-				break;
-			case ICodeAnalyzer.SuppressionScope.suppressThisMessageFileLine:
-				suppressionLine = p.MessageId + ":" + simpleFileName + ":" + p.Line;
-				break;
-			case ICodeAnalyzer.SuppressionScope.suppressThisMessageFileOnly:
-				suppressionLine = p.MessageId + ":" + simpleFileName;
-				break;
-			case ICodeAnalyzer.SuppressionScope.suppressThisMessageGlobally:
-				suppressionLine = p.MessageId; // TODO:
-				break;
-			case ICodeAnalyzer.SuppressionScope.suppressThisMessageProjectOnly:
-				suppressionLine = p.MessageId;
-				break;
+					break;
+				case ICodeAnalyzer.SuppressionScope.suppressThisMessageFileLine:
+					suppressionLine = p.MessageId + ":" + simpleFileName + ":" + p.Line;
+					break;
+				case ICodeAnalyzer.SuppressionScope.suppressThisMessageFileOnly:
+					suppressionLine = p.MessageId + ":" + simpleFileName;
+					break;
+				case ICodeAnalyzer.SuppressionScope.suppressThisMessageGlobally:
+					suppressionLine = p.MessageId; // TODO:
+					break;
+				case ICodeAnalyzer.SuppressionScope.suppressThisMessageProjectOnly:
+					suppressionLine = p.MessageId;
+					break;
+				default:
+					throw new InvalidOperationException("Unsupported value: " + scope.ToString());
 			}
 
 			String suppresionsFilePath = p.BaseProjectPath + "\\suppressions.cfg";

--- a/CPPCheckPlugin/ICodeAnalyzer.cs
+++ b/CPPCheckPlugin/ICodeAnalyzer.cs
@@ -7,7 +7,15 @@ namespace VSPackage.CPPCheckPlugin
 {
 	public abstract class ICodeAnalyzer : IDisposable
 	{
-		public enum SuppressionScope { suppressThisMessageGlobally, suppressThisMessageProjectOnly, suppressThisMessageFileOnly, suppressThisMessageFileLine, suppressAllMessagesThisFile };
+		public enum SuppressionScope
+		{
+			suppressThisMessageGlobally,
+			suppressThisMessageProjectOnly,
+			suppressThisMessageFileOnly,
+			suppressThisMessageFileLine,
+			suppressAllMessagesThisFile
+		};
+
 		public enum AnalysisType { DocumentSavedAnalysis, ProjectAnalysis };
 
 		protected ICodeAnalyzer()

--- a/CPPCheckPlugin/MainToolWindowUI.xaml.cs
+++ b/CPPCheckPlugin/MainToolWindowUI.xaml.cs
@@ -48,46 +48,36 @@ namespace VSPackage.CPPCheckPlugin
 
 		private void menuItem_suppressThisMessageGlobally(object sender, RoutedEventArgs e)
 		{
-			foreach (ProblemsListItem item in listView.SelectedItems)
-			{
-				if (item != null)
-					SuppressionRequested(this, new SuppresssionRequestedEventArgs(item.Problem, ICodeAnalyzer.SuppressionScope.suppressThisMessageGlobally));
-			}
+			menuItem_SuppressSelected(ICodeAnalyzer.SuppressionScope.suppressThisMessageGlobally);
 		}
 
 		private void menuItem_suppressThisMessageProjectOnly(object sender, RoutedEventArgs e)
 		{
-			foreach (ProblemsListItem item in listView.SelectedItems)
-			{
-				if (item != null)
-					SuppressionRequested(this, new SuppresssionRequestedEventArgs(item.Problem, ICodeAnalyzer.SuppressionScope.suppressThisMessageProjectOnly));
-			}
+			menuItem_SuppressSelected(ICodeAnalyzer.SuppressionScope.suppressThisMessageProjectOnly);
 		}
 
 		private void menuItem_suppressThisMessageFileOnly(object sender, RoutedEventArgs e)
 		{
-			foreach (ProblemsListItem item in listView.SelectedItems)
-			{
-				if (item != null)
-					SuppressionRequested(this, new SuppresssionRequestedEventArgs(item.Problem, ICodeAnalyzer.SuppressionScope.suppressThisMessageFileOnly));
-			}
+			menuItem_SuppressSelected(ICodeAnalyzer.SuppressionScope.suppressThisMessageFileOnly);
 		}
 
 		private void menuItem_suppressThisMessageFileLine(object sender, RoutedEventArgs e)
 		{
-			foreach (ProblemsListItem item in listView.SelectedItems)
-			{
-				if (item != null)
-					SuppressionRequested(this, new SuppresssionRequestedEventArgs(item.Problem, ICodeAnalyzer.SuppressionScope.suppressThisMessageFileLine));
-			}
+			menuItem_SuppressSelected(ICodeAnalyzer.SuppressionScope.suppressThisMessageFileLine);
 		}
 
 		private void menuItem_suppressAllMessagesThisFile(object sender, RoutedEventArgs e)
 		{
-			foreach (ProblemsListItem item in listView.SelectedItems)
+			menuItem_SuppressSelected(ICodeAnalyzer.SuppressionScope.suppressAllMessagesThisFile);
+		}
+
+		private void menuItem_SuppressSelected(ICodeAnalyzer.SuppressionScope scope)
+		{
+			var selectedItems = listView.SelectedItems;
+			foreach (ProblemsListItem item in selectedItems)
 			{
 				if (item != null)
-					SuppressionRequested(this, new SuppresssionRequestedEventArgs(item.Problem, ICodeAnalyzer.SuppressionScope.suppressAllMessagesThisFile));
+					SuppressionRequested(this, new SuppresssionRequestedEventArgs(item.Problem, scope));
 			}
 		}
 
@@ -154,8 +144,7 @@ namespace VSPackage.CPPCheckPlugin
 							bitmap = new System.Drawing.Icon(SystemIcons.Error, SystemIcons.Error.Height, SystemIcons.Error.Width).ToBitmap();
 							break;
 						default:
-							bitmap = new System.Drawing.Icon(SystemIcons.Information, SystemIcons.Information.Height, SystemIcons.Information.Width).ToBitmap();
-							break;
+							throw new InvalidOperationException("Unsupported value: " + _problem.Severity.ToString());
 					}
 					ImageSource imgSource = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(bitmap.GetHbitmap(), IntPtr.Zero, System.Windows.Int32Rect.Empty, BitmapSizeOptions.FromWidthAndHeight(bitmap.Width, bitmap.Height));
 					return imgSource;


### PR DESCRIPTION
This removes unneeded code duplication and cleans up enum handling:
- all-in-one-line declarations
- doing nothing when an unhandled enum value is encountered
- inconsistent indenting
