### PR TITLE
No need to kill process that already exited.

### DIFF
--- a/CPPCheckPlugin/ICodeAnalyzer.cs
+++ b/CPPCheckPlugin/ICodeAnalyzer.cs
@@ -128,6 +128,7 @@ namespace VSPackage.CPPCheckPlugin
 					_outputPane.OutputString("Analysis completed in " + timeElapsed.ToString() + " seconds\n");
 				}
 				process.Close();
+				process = null;
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
This code was broken by this commit https://github.com/VioletGiraffe/cppcheck-vs-addin/commit/615a484860dff7e014fa1d90b39ecad961cc365c#diff-b7edabae74f3f333dd2aa71e3f063a2dL122 Note `process = null` line removed for no reason.
