### PR TITLE
Remove using "as" in ways it would help mask errors.

### DIFF
--- a/CPPCheckPlugin/ChecksPanel.cs
+++ b/CPPCheckPlugin/ChecksPanel.cs
@@ -213,7 +213,7 @@ namespace VSPackage.CPPCheckPlugin
 
 		private void Severity_Changed(object sender, System.Windows.RoutedEventArgs e)
 		{
-			var box = sender as CheckBox;
+			var box = (CheckBox)sender;
 			if (mChecks.ContainsKey(box.Name))
 			{
 				mChecks[box.Name].scrollView.IsEnabled = box.IsChecked == true;

--- a/CPPCheckPlugin/MainToolWindow.cs
+++ b/CPPCheckPlugin/MainToolWindow.cs
@@ -92,7 +92,7 @@ namespace VSPackage.CPPCheckPlugin
 			EnvDTE.DTE dte = (EnvDTE.DTE)GetService(typeof(SDTE));
 			Debug.Assert(dte != null);
 			Debug.Assert(dte.ActiveDocument != null);
-			EnvDTE.TextSelection selection = dte.ActiveDocument.Selection as EnvDTE.TextSelection;
+			var selection = (EnvDTE.TextSelection)dte.ActiveDocument.Selection;
 			Debug.Assert(selection != null);
 			selection.GotoLine(problem.Line);
 		}


### PR DESCRIPTION
This will cause earlier InvalidCastException instead of later NullReferenceException as it would be with abusing _as_.
