### PR TITLE
Cleanup settings manipulation

### DIFF
--- a/CPPCheckPlugin/AnalyzerCppcheck.cs
+++ b/CPPCheckPlugin/AnalyzerCppcheck.cs
@@ -177,7 +177,7 @@ namespace VSPackage.CPPCheckPlugin
 				analyzerPath = dialog.FileName;
 			}
 
-			Properties.Settings.Default["CPPcheckPath"] = analyzerPath;
+			Properties.Settings.Default.CPPcheckPath = analyzerPath;
 			Properties.Settings.Default.Save();
 			run(analyzerPath, cppheckargs, outputWindow);
 		}

--- a/CPPCheckPlugin/CPPCheckPluginPackage.cs
+++ b/CPPCheckPlugin/CPPCheckPluginPackage.cs
@@ -149,7 +149,7 @@ namespace VSPackage.CPPCheckPlugin
 			_analyzers.Add(cppcheckAnalayzer);
 
 			if (String.IsNullOrEmpty(Properties.Settings.Default.DefaultArguments))
-				Properties.Settings.Default["DefaultArguments"] = CppcheckSettings.DefaultArguments;
+				Properties.Settings.Default.DefaultArguments = CppcheckSettings.DefaultArguments;
 
 			// Add our command handlers for menu (commands must exist in the .vsct file)
 			OleMenuCommandService mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
@@ -210,7 +210,7 @@ namespace VSPackage.CPPCheckPlugin
 			if (document == null || document.Language != "C/C++")
 				return;
 
-			if (Properties.Settings.Default[Properties.Settings.CheckSavedFilesOptionKeyName] != null && Properties.Settings.Default.CheckSavedFiles == false)
+			if (Properties.Settings.Default.CheckSavedFilesHasValue && Properties.Settings.Default.CheckSavedFiles == false)
 				return;
 
 			if (document.ActiveWindow == null)
@@ -240,7 +240,7 @@ namespace VSPackage.CPPCheckPlugin
 				if (sourceForAnalysis == null)
 					return;
 
-				if (Properties.Settings.Default[Properties.Settings.CheckSavedFilesOptionKeyName] == null)
+				if (!Properties.Settings.Default.CheckSavedFilesHasValue)
 				{
 					askCheckSavedFiles();
 

--- a/CPPCheckPlugin/CppcheckSettings.xaml.cs
+++ b/CPPCheckPlugin/CppcheckSettings.xaml.cs
@@ -28,13 +28,13 @@ namespace VSPackage.CPPCheckPlugin
 			Closed += OnClosed;
 
 			if (String.IsNullOrWhiteSpace(Properties.Settings.Default.DefaultArguments))
-				Properties.Settings.Default["DefaultArguments"] = DefaultArguments;
+				Properties.Settings.Default.DefaultArguments = DefaultArguments;
 			else
-				Properties.Settings.Default["DefaultArguments"] = Properties.Settings.Default.DefaultArguments.Replace("--template=vs", "--template=\"{file}|{line}|{severity}|{id}|{message}\"");
+				Properties.Settings.Default.DefaultArguments = Properties.Settings.Default.DefaultArguments.Replace("--template=vs", "--template=\"{file}|{line}|{severity}|{id}|{message}\"");
 
 			Properties.Settings.Default.Save();
 
-			if (Properties.Settings.Default[Properties.Settings.CheckSavedFilesOptionKeyName] == null)
+			if (!Properties.Settings.Default.CheckSavedFilesHasValue)
 			{
 				CPPCheckPluginPackage.askCheckSavedFiles();
 			}
@@ -46,7 +46,7 @@ namespace VSPackage.CPPCheckPlugin
 
 			InconclusiveChecks.IsChecked = settings.InconclusiveChecksEnabled;
 
-			if (settings[Properties.Settings.CheckSavedFilesOptionKeyName] == null)
+			if (!settings.CheckSavedFilesHasValue)
 				CheckSavedFiles.IsChecked = false;
 			else
 				CheckSavedFiles.IsChecked = settings.CheckSavedFiles;
@@ -57,62 +57,62 @@ namespace VSPackage.CPPCheckPlugin
 
 		private void OnClosed(object o, EventArgs e)
 		{
-			Properties.Settings.Default["DefaultArguments"] = String.IsNullOrEmpty(ArgumentsEditor.Text) ? DefaultArguments.Replace('\n', ' ').Replace('\r', ' ') : ArgumentsEditor.Text;
+			Properties.Settings.Default.DefaultArguments = String.IsNullOrEmpty(ArgumentsEditor.Text) ? DefaultArguments.Replace('\n', ' ').Replace('\r', ' ') : ArgumentsEditor.Text;
 			Properties.Settings.Default.Save();
 		}
 
 		private void inconclusive_Unchecked(object sender, RoutedEventArgs e)
 		{
-			Properties.Settings.Default["InconclusiveChecksEnabled"] = false;
+			Properties.Settings.Default.InconclusiveChecksEnabled = false;
 			Properties.Settings.Default.Save();
 		}
 
 		private void inconclusive_Checked(object sender, RoutedEventArgs e)
 		{
-			Properties.Settings.Default["InconclusiveChecksEnabled"] = true;
+			Properties.Settings.Default.InconclusiveChecksEnabled = true;
 			Properties.Settings.Default.Save();
 		}
 
 		private void checkSavedFiles_Unchecked(object sender, RoutedEventArgs e)
 		{
-			Properties.Settings.Default[Properties.Settings.CheckSavedFilesOptionKeyName] = false;
+			Properties.Settings.Default.CheckSavedFiles = false;
 			Properties.Settings.Default.Save();
 		}
 
 		private void checkSavedFiles_Checked(object sender, RoutedEventArgs e)
 		{
-			Properties.Settings.Default[Properties.Settings.CheckSavedFilesOptionKeyName] = true;
+			Properties.Settings.Default.CheckSavedFiles = true;
 			Properties.Settings.Default.Save();
 		}
 
 		private void onDefaultArguments(object sender, RoutedEventArgs e)
 		{
-			Properties.Settings.Default["DefaultArguments"] = DefaultArguments;
+			Properties.Settings.Default.DefaultArguments = DefaultArguments;
 			ArgumentsEditor.Text = DefaultArguments;
 			Properties.Settings.Default.Save();
 		}
 
 		private void Project_OnlyCheckCurrentConfig_Checked(object sender, RoutedEventArgs e)
 		{
-			Properties.Settings.Default["ProjectOnlyCheckCurrentConfig"] = true;
+			Properties.Settings.Default.ProjectOnlyCheckCurrentConfig = true;
 			Properties.Settings.Default.Save();
 		}
 
 		private void Project_OnlyCheckCurrentConfig_Unchecked(object sender, RoutedEventArgs e)
 		{
-			Properties.Settings.Default["ProjectOnlyCheckCurrentConfig"] = false;
+			Properties.Settings.Default.ProjectOnlyCheckCurrentConfig = false;
 			Properties.Settings.Default.Save();
 		}
 
 		private void File_OnlyCheckCurrentConfig_Checked(object sender, RoutedEventArgs e)
 		{
-			Properties.Settings.Default["FileOnlyCheckCurrentConfig"] = true;
+			Properties.Settings.Default.FileOnlyCheckCurrentConfig = true;
 			Properties.Settings.Default.Save();
 		}
 
 		private void File_OnlyCheckCurrentConfig_Unchecked(object sender, RoutedEventArgs e)
 		{
-			Properties.Settings.Default["FileOnlyCheckCurrentConfig"] = false;
+			Properties.Settings.Default.FileOnlyCheckCurrentConfig = false;
 			Properties.Settings.Default.Save();
 		}
 

--- a/CPPCheckPlugin/Settings.cs
+++ b/CPPCheckPlugin/Settings.cs
@@ -25,6 +25,16 @@
             // Add code to handle the SettingsSaving event here.
         }
 
-        public const string CheckSavedFilesOptionKeyName = "CheckSavedFiles";
+        private const string CheckSavedFilesOptionKeyName = "CheckSavedFiles";
+
+        public bool CheckSavedFilesHasValue {
+            get {
+                if (this[CheckSavedFilesOptionKeyName] == null)
+                {
+                    return false;
+                }
+                return true;
+            }
+        }
     }
 }


### PR DESCRIPTION
Maybe I don't get it, but looks like there's no point in using string literals when there's already an accessor method to do the same.
