### PR TITLE
Start CppCheck in correct working directory

### DIFF
--- a/CPPCheckPlugin/ChecksPanel.cs
+++ b/CPPCheckPlugin/ChecksPanel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Windows.Controls;
 using System.Xml;
 
@@ -153,6 +154,7 @@ namespace VSPackage.CPPCheckPlugin
 				startInfo.UseShellExecute = false;
 				startInfo.CreateNoWindow = true;
 				startInfo.RedirectStandardOutput = true;
+				startInfo.WorkingDirectory = Path.GetDirectoryName(Properties.Settings.Default.CPPcheckPath);
 				startInfo.FileName = Properties.Settings.Default.CPPcheckPath;
 				startInfo.Arguments = "--errorlist --xml-version=2";
 				process.Start();

--- a/CPPCheckPlugin/ICodeAnalyzer.cs
+++ b/CPPCheckPlugin/ICodeAnalyzer.cs
@@ -184,6 +184,7 @@ namespace VSPackage.CPPCheckPlugin
 
 				process = new System.Diagnostics.Process();
 				process.StartInfo.FileName = analyzerExePath;
+				process.StartInfo.WorkingDirectory = Path.GetDirectoryName(analyzerExePath);
 				process.StartInfo.Arguments = arguments;
 				process.StartInfo.CreateNoWindow = true;
 


### PR DESCRIPTION
...to avoid automatically including the "Microsoft Visual Studio X.X" folder and therefore all of its template code files. Otherwise, this causes lots of trouble with MSVC2013 since cppcheck will also check all installed Visual Studio templates and example projects.