### PR TITLE
Fixed minor issues with column sorting

### DIFF
--- a/CPPCheckPlugin/MainToolWindow.cs
+++ b/CPPCheckPlugin/MainToolWindow.cs
@@ -57,6 +57,7 @@ namespace VSPackage.CPPCheckPlugin
 		public void clear()
 		{
 			_listView.Items.Clear();
+            _ui.ClearSorting();
 		}
 
 		public bool isEmpty()

--- a/CPPCheckPlugin/MainToolWindowUI.xaml
+++ b/CPPCheckPlugin/MainToolWindowUI.xaml
@@ -78,7 +78,7 @@
                     </GridViewColumn>
                     <GridViewColumn x:Name="LineColumn" DisplayMemberBinding="{Binding Line}" Width="Auto">
                         <GridViewColumn.Header>
-                            <GridViewColumnHeader Tag="Line" Click="problemColumnHeader_Click">Line</GridViewColumnHeader>
+                            <GridViewColumnHeader Tag="Line">Line</GridViewColumnHeader>
                         </GridViewColumn.Header>
                     </GridViewColumn>
                     <GridViewColumn x:Name="MessageColumn" DisplayMemberBinding="{Binding Message}" Width="{Binding ElementName=helperField, Path=ActualWidth}">

--- a/CPPCheckPlugin/MainToolWindowUI.xaml.cs
+++ b/CPPCheckPlugin/MainToolWindowUI.xaml.cs
@@ -44,8 +44,6 @@ namespace VSPackage.CPPCheckPlugin
 		public MainToolWindowUI()
 		{
 			InitializeComponent();
-
-            
 		}
 
 		private void menuItem_suppressThisMessageProjectWide(object sender, RoutedEventArgs e)
@@ -134,15 +132,13 @@ namespace VSPackage.CPPCheckPlugin
             GridViewColumnHeader column = (sender as GridViewColumnHeader);
             string sortBy = column.Tag.ToString();
 
-            if(listViewSortCol != null)
-            {
-                    AdornerLayer.GetAdornerLayer(listViewSortCol).Remove(listViewSortAdorner);
-                    listView.Items.SortDescriptions.Clear();
-            }
+            ClearSorting();
 
             ListSortDirection newDir = ListSortDirection.Ascending;
-            if(listViewSortCol == column && listViewSortAdorner.Direction == newDir)
-                    newDir = ListSortDirection.Descending;
+            if (listViewSortCol == column && listViewSortAdorner.Direction == newDir)
+            {
+                newDir = ListSortDirection.Descending;
+            }
 
             listViewSortCol = column;
             listViewSortAdorner = new SortAdorner(listViewSortCol, newDir);
@@ -159,11 +155,6 @@ namespace VSPackage.CPPCheckPlugin
                 listView.Items.SortDescriptions.Add(new SortDescription(sortBy, newDir));
                 listView.Items.SortDescriptions.Add(new SortDescription("Line", ListSortDirection.Ascending));
             }
-            else if (sortBy == "Line")
-            {
-                listView.Items.SortDescriptions.Add(new SortDescription(sortBy, newDir));
-                listView.Items.SortDescriptions.Add(new SortDescription("FileName", ListSortDirection.Ascending));
-            }
             else if (sortBy == "Message")
             {
                 listView.Items.SortDescriptions.Add(new SortDescription(sortBy, newDir));
@@ -173,6 +164,15 @@ namespace VSPackage.CPPCheckPlugin
             else
             {
                 listView.Items.SortDescriptions.Add(new SortDescription(sortBy, newDir));
+            }
+        }
+
+        public void ClearSorting()
+        {
+            if(listViewSortCol != null)
+            {
+                AdornerLayer.GetAdornerLayer(listViewSortCol).Remove(listViewSortAdorner);
+                listView.Items.SortDescriptions.Clear();
             }
         }
 
@@ -269,11 +269,8 @@ namespace VSPackage.CPPCheckPlugin
 
     public class SortAdorner : Adorner
     {
-        private static Geometry ascGeometry =
-                Geometry.Parse("M 0 4 L 3.5 0 L 7 4 Z");
-
-        private static Geometry descGeometry =
-                Geometry.Parse("M 0 0 L 3.5 4 L 7 0 Z");
+        private static Geometry ascGeometry = Geometry.Parse("M 0 4 L 3.5 0 L 7 4 Z");
+        private static Geometry descGeometry = Geometry.Parse("M 0 0 L 3.5 4 L 7 0 Z");
 
         public ListSortDirection Direction { get; private set; }
 
@@ -288,14 +285,18 @@ namespace VSPackage.CPPCheckPlugin
             base.OnRender(drawingContext);
 
             if (AdornedElement.RenderSize.Width < 20)
+            {
                 return;
+            }
 
             TranslateTransform transform = new TranslateTransform(AdornedElement.RenderSize.Width - 15, (AdornedElement.RenderSize.Height - 5) / 2);
             drawingContext.PushTransform(transform);
 
             Geometry geometry = ascGeometry;
             if (this.Direction == ListSortDirection.Descending)
+            {
                 geometry = descGeometry;
+            }
             drawingContext.DrawGeometry(System.Windows.Media.Brushes.Black, null, geometry);
 
             drawingContext.Pop();


### PR DESCRIPTION
Disabled sorting on line numbers since it makes no sense (i.e. it is not useful) and looks ugly in UI. Sorting settings are now cleared when doing a new check (before, the ascending/descending icon was left from the last result view, but the result wasn't sorted according to it). Some minor code cleanup of the sorting code.