### PR TITLE
improved temp file handling to make sure we cleanup old files in the event of failure

### DIFF
--- a/CPPCheckPlugin/AnalyzerCppcheck.cs
+++ b/CPPCheckPlugin/AnalyzerCppcheck.cs
@@ -11,6 +11,35 @@ namespace VSPackage.CPPCheckPlugin
 {
 	class AnalyzerCppcheck : ICodeAnalyzer
 	{
+		private const string tempFilePrefix = "CPPCheckPlugin";
+		
+		public AnalyzerCppcheck()
+		{
+			// Perform some cleanup of old temporary files
+			string tempPath = Path.GetTempPath();
+			
+			try 
+			{
+				// Get all files that have our unique prefix
+				string[] oldFiles = Directory.GetFiles(tempPath, tempFilePrefix + "*");
+				
+				foreach (string file in oldFiles) 
+				{
+					DateTime fileModifiedDate = File.GetLastWriteTime(file);
+					
+                    if (fileModifiedDate.AddMinutes(60) < DateTime.Now)
+					{
+                        // File hasn't been written to in the last 60 mins, so it must be 
+                        // from an earlier instance which didn't exit gracefully.
+						File.Delete(file);
+					}
+				}
+			} 
+			catch (Exception e) 
+			{
+			}
+		}
+		
 		~AnalyzerCppcheck()
 		{
 			// Delete the temp file. Doesn't throw an exception if the file was never
@@ -345,6 +374,6 @@ namespace VSPackage.CPPCheckPlugin
 		}
 		
 		private Problem _unfinishedProblem = null;
-		private string tempFileName = Path.GetTempFileName();
+		private string tempFileName = Path.GetTempPath() + tempFilePrefix + "_" + Path.GetRandomFileName();
 	}
 }

--- a/CPPCheckPlugin/AnalyzerCppcheck.cs
+++ b/CPPCheckPlugin/AnalyzerCppcheck.cs
@@ -174,11 +174,12 @@ namespace VSPackage.CPPCheckPlugin
 			if (!allConfiguredFiles.Any())
 				return;
 
-			StreamWriter tempFile = new StreamWriter(tempFileName);
-
 			List<string> cppheckargs = new List<string>();
-			foreach (var configuredFiles in allConfiguredFiles)
-				cppheckargs.Add(getCPPCheckArgs(configuredFiles, analysisOnSavedFile, allConfiguredFiles.Count > 1, tempFile));
+			using( StreamWriter tempFile = new StreamWriter(tempFileName) )
+			{
+				foreach (var configuredFiles in allConfiguredFiles)
+					cppheckargs.Add(getCPPCheckArgs(configuredFiles, analysisOnSavedFile, allConfiguredFiles.Count > 1, tempFile));
+			}
 
 			string analyzerPath = Properties.Settings.Default.CPPcheckPath;
 			while (!File.Exists(analyzerPath))
@@ -191,8 +192,6 @@ namespace VSPackage.CPPCheckPlugin
 				analyzerPath = dialog.FileName;
 			}
 
-			tempFile.Close();
-            
 			Properties.Settings.Default.CPPcheckPath = analyzerPath;
 			Properties.Settings.Default.Save();
 			
@@ -337,8 +336,8 @@ namespace VSPackage.CPPCheckPlugin
 			// created, so we don't need to worry about that.
 			File.Delete(tempFileName);
 		}
-
+		
 		private Problem _unfinishedProblem = null;
-		string tempFileName = Path.GetTempFileName();
+		private string tempFileName = Path.GetTempFileName();
 	}
 }

--- a/CPPCheckPlugin/AnalyzerCppcheck.cs
+++ b/CPPCheckPlugin/AnalyzerCppcheck.cs
@@ -27,10 +27,10 @@ namespace VSPackage.CPPCheckPlugin
 				{
 					DateTime fileModifiedDate = File.GetLastWriteTime(file);
 					
-                    if (fileModifiedDate.AddMinutes(60) < DateTime.Now)
+					if (fileModifiedDate.AddMinutes(60) < DateTime.Now)
 					{
-                        // File hasn't been written to in the last 60 mins, so it must be 
-                        // from an earlier instance which didn't exit gracefully.
+						// File hasn't been written to in the last 60 mins, so it must be 
+						// from an earlier instance which didn't exit gracefully.
 						File.Delete(file);
 					}
 				}

--- a/CPPCheckPlugin/AnalyzerCppcheck.cs
+++ b/CPPCheckPlugin/AnalyzerCppcheck.cs
@@ -34,10 +34,8 @@ namespace VSPackage.CPPCheckPlugin
 						File.Delete(file);
 					}
 				}
-			} 
-			catch (Exception e) 
-			{
 			}
+			catch (System.Exception) {}
 		}
 		
 		~AnalyzerCppcheck()

--- a/CPPCheckPlugin/AnalyzerCppcheck.cs
+++ b/CPPCheckPlugin/AnalyzerCppcheck.cs
@@ -11,6 +11,13 @@ namespace VSPackage.CPPCheckPlugin
 {
 	class AnalyzerCppcheck : ICodeAnalyzer
 	{
+		~AnalyzerCppcheck()
+		{
+			// Delete the temp file. Doesn't throw an exception if the file was never
+			// created, so we don't need to worry about that.
+			File.Delete(tempFileName);
+		}
+		
 		private string getCPPCheckArgs(ConfiguredFiles configuredFiles, bool analysisOnSavedFile, bool multipleProjects, StreamWriter tempFile)
 		{
 			Debug.Assert(_numCores > 0);


### PR DESCRIPTION
Based on discussion here: https://github.com/gkelly-si/cppcheck-vs-addin/commit/90ed776666338ba1609e2fba640af3a163a2a833#commitcomment-10986974

Some further changes to make sure we have code to handle exceptions, and further code to cleanup old files if Visual Studio itself had crashed.