### PR TITLE
Fix issue #109: allow .NET versions > 4.5.

### DIFF
--- a/CPPCheckPlugin/source.extension.vsixmanifest
+++ b/CPPCheckPlugin/source.extension.vsixmanifest
@@ -12,7 +12,7 @@
     <InstallationTarget Id="Microsoft.VisualStudio.Ultimate" Version="[11.0,14.0]" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="11.0" />
   </Dependencies>
   <Assets>


### PR DESCRIPTION
You may want to play safe and limit the versions somehow, e.g. [4.5, 5.0) or even [4.5, 4.6].