### PR TITLE
Catch exception for invalid paths

### DIFF
--- a/CPPCheckPlugin/SourceFile.cs
+++ b/CPPCheckPlugin/SourceFile.cs
@@ -64,16 +64,16 @@ namespace VSPackage.CPPCheckPlugin
 			if (String.IsNullOrEmpty(path)|| path.Equals(".") || path.Equals("\\\".\\\""))
 				return;
 
-      bool isAbsolutePath = false;
-      try
-      {
-        isAbsolutePath = System.IO.Path.IsPathRooted(path);
-      }
-      catch (System.ArgumentException)
-      {
-        // seems like an invalid path, ignore
-        return;
-      }
+			bool isAbsolutePath = false;
+			try
+			{
+				isAbsolutePath = System.IO.Path.IsPathRooted(path);
+			}
+			catch (System.ArgumentException)
+			{
+				// seems like an invalid path, ignore
+				return;
+			}
 
 			if (isAbsolutePath) // absolute path
 				_includePaths.Add(cleanPath(path));

--- a/CPPCheckPlugin/SourceFile.cs
+++ b/CPPCheckPlugin/SourceFile.cs
@@ -63,7 +63,19 @@ namespace VSPackage.CPPCheckPlugin
 				return;
 			if (String.IsNullOrEmpty(path)|| path.Equals(".") || path.Equals("\\\".\\\""))
 				return;
-			if (path.Contains("\\:")) // absolute path
+
+      bool isAbsolutePath = false;
+      try
+      {
+        isAbsolutePath = System.IO.Path.IsPathRooted(path);
+      }
+      catch (System.ArgumentException)
+      {
+        // seems like an invalid path, ignore
+        return;
+      }
+
+			if (isAbsolutePath) // absolute path
 				_includePaths.Add(cleanPath(path));
 			else
 			{


### PR DESCRIPTION
This resolves issue #157 where absolute include paths from a property sheet (e.g. d:\\include) confuse the path handling and an ArgumentException because of invalid characters in path name is thrown.

In general, i think the pathhandling needs some more attention, especially SourceFile::cleanPath().