### PR TITLE
Explain CppCheck is not deployed by add-in installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Visual Studio 2012, 2013 and 2015 (except Express editions) supported.
 
 **<a href="https://github.com/VioletGiraffe/cppcheck-vs-addin/releases/latest">Get the latest release</a>**
 
+NOTE: The add-in does not deploy CppCheck executable. Please, go to [Cppcheck](http://cppcheck.sourceforge.net/) webiste, download the installer and install it before first use of the add-in. The add-in then may prompt for location of the `cppcheck.exe`.
+
 ### Contributors
 
 Should you decide to open, build and debug the project please follow these steps:


### PR DESCRIPTION
It might not be obvious. Especially, other add-ins, like clang-format plugin for Visual Studio, deploy required executable.