### PR TITLE
Fix for problems discussed in Issue#175

### DIFF
--- a/CPPCheckPlugin/AnalyzerCppcheck.cs
+++ b/CPPCheckPlugin/AnalyzerCppcheck.cs
@@ -149,7 +149,7 @@ namespace VSPackage.CPPCheckPlugin
 			{
 				foreach (SourceFile file in filesToAnalyze)
 				{
-					if (!matchMasksList(file.FileName, unitedSuppressionsInfo.SkippedFilesMask))
+					if (!matchMasksList(file.FilePath, unitedSuppressionsInfo.SkippedFilesMask))
 						tempFile.WriteLine(file.FilePath);
 				}
 			}

--- a/CPPCheckPlugin/CPPCheckPluginPackage.cs
+++ b/CPPCheckPlugin/CPPCheckPluginPackage.cs
@@ -501,7 +501,7 @@ namespace VSPackage.CPPCheckPlugin
 						if (file != null)
 						{
 							// document selected
-							SourceFile sourceFile = createSourceFileAsync(file.FullPath, configuration, project.Object);
+							SourceFile sourceFile = await createSourceFileAsync(file.FullPath, configuration, project.Object);
 							addEntry(currentConfiguredFiles, sourceFile, project);
 						}
 					}


### PR DESCRIPTION
Workaround for failure to load VCProjectEngine interface discussed in issue #175 plus potential side-effect of the real underlying problem (which remains unfixed) and async error that was mentioned in the same thread at the end. Pretty sure this is also issue #204 because (as observed in the discussion for the earlier issue, the behaviour of the GetInterface failure was changed along with changes for VS2019 support). 