### PR TITLE
Fix project scanning

### DIFF
--- a/CPPCheckPlugin/AnalyzerCppcheck.cs
+++ b/CPPCheckPlugin/AnalyzerCppcheck.cs
@@ -75,7 +75,7 @@ namespace VSPackage.CPPCheckPlugin
 			return analyzerPath;
 		}
 
-		private string getCPPCheckArgs(SourceFilesWithConfiguration configuredFiles, bool analysisOnSavedFile, bool multipleProjects, string tempFileName)
+		private string getCPPCheckArgs(SourceFilesWithConfiguration configuredFiles, bool analysisOnSavedFile, string tempFileName)
 		{
 			if (!configuredFiles.Any())
 			{
@@ -116,8 +116,7 @@ namespace VSPackage.CPPCheckPlugin
 				unitedSuppressionsInfo.UnionWith(readSuppressions(SuppressionStorage.Project, path, filesToAnalyze.First().ProjectName));
 			}
 
-			if (!multipleProjects)
-				cppheckargs += (" --relative-paths=\"" + filesToAnalyze.First().BaseProjectPath + "\"");
+			cppheckargs += (" --relative-paths=\"" + _projectBasePath + "\"");
 			cppheckargs += (" -j " + _numCores.ToString());
 			if (Properties.Settings.Default.InconclusiveChecksEnabled)
 				cppheckargs += " --inconclusive ";
@@ -278,7 +277,7 @@ namespace VSPackage.CPPCheckPlugin
 
 			List<string> cppheckargs = new List<string>();
 			foreach (var configuredFiles in allConfiguredFiles)
-				cppheckargs.Add(getCPPCheckArgs(configuredFiles, analysisOnSavedFile, allConfiguredFiles.Count > 1, createNewTempFileName()));
+				cppheckargs.Add(getCPPCheckArgs(configuredFiles, analysisOnSavedFile, createNewTempFileName()));
 
 			run(cppcheckExePath(), cppheckargs);
 		}

--- a/CPPCheckPlugin/CPPCheckPlugin.vsct
+++ b/CPPCheckPlugin/CPPCheckPlugin.vsct
@@ -34,7 +34,7 @@
     group; your package should define its own command set in order to avoid collisions  
     with command ids defined by other packages. -->
 
-    
+
     <!-- In this section you can define new menu groups. A menu group is a container for 
          other menus or buttons (commands); from a visual point of view you can see the 
          group as the part of a menu contained between two lines. The parent of a group 
@@ -68,9 +68,9 @@
       <Group guid="guidCPPCheckPluginMultiItemCmdSet" id="MyMultiItemMenuGroup" priority="0x0600">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
       </Group>
-      
+
     </Groups>
-    
+
     <!--Buttons section. -->
     <!--This section defines the elements the user can interact with, like a menu command or a button 
         or combo box in a toolbar. -->
@@ -90,7 +90,7 @@
           <ButtonText>Check current project with cppcheck</ButtonText>
         </Strings>
       </Button>
-      
+
       <Button guid="guidCPPCheckPluginCmdSet" id="cmdidCheckMultiItemCppcheck" priority="0x0100" type="Button">
         <Parent guid="guidCPPCheckPluginCmdSet" id="MyMenuGroup" />
         <Icon guid="guidImages" id="bmpPic1" />
@@ -132,7 +132,7 @@
         </Strings>
       </Button>
 
-      <Button guid="guidCPPCheckPluginMultiItemCmdSet" id="cmdidCheckMultiItemCppcheck" priority="0x0100" type="Button">
+      <Button guid="guidCPPCheckPluginMultiItemCmdSet" id="cmdidCheckMultiItemCppcheck1" priority="0x0100" type="Button">
         <Parent guid="guidCPPCheckPluginMultiItemCmdSet" id="MyMultiItemMenuGroup" />
         <Icon guid="guidImages" id="bmpPic1" />
         <Strings>
@@ -141,7 +141,7 @@
       </Button>
 
     </Buttons>
-   
+
     <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
     <Bitmaps>
       <!--  The bitmap id is defined in a way that is a little bit different from the others: 
@@ -150,16 +150,16 @@
             inside a button definition. An important aspect of this declaration is that the element id 
             must be the actual index (1-based) of the bitmap inside the bitmap strip. -->
       <Bitmap guid="guidImages" href="Resources\Images.png" usedList="bmpPic1, bmpPic2, bmpPicSearch, bmpPicX, bmpPicArrows"/>
-      
+
     </Bitmaps>
- 
+
   </Commands>
 
 
   <Symbols>
     <!-- This is the package guid. -->
     <GuidSymbol name="guidCPPCheckPluginPkg" value="{127d8bd3-8cd7-491a-9a63-9b4e89118da9}" />
-    
+
     <!-- This is the guid used to group the menu commands together -->
     <GuidSymbol name="guidCPPCheckPluginCmdSet" value="{7fcb87ef-4f0c-4713-8217-5bef43dc0de4}">
 
@@ -169,20 +169,20 @@
       <IDSymbol name="cmdidStopCppcheck" value="0x0103" />
       <IDSymbol name="cmdidSettings" value="0x0104" />
     </GuidSymbol>
-    
+
     <GuidSymbol name="guidCPPCheckPluginProjectCmdSet" value="{9019df3f-c4aa-499b-b46a-0bcb43d006db}">
       <IDSymbol name="MyProjectMenuGroup" value="0x1022" />
-      <IDSymbol name="cmdidCheckProjectCppcheck1" value="0x0100" />
+      <IDSymbol name="cmdidCheckProjectCppcheck1" value="0x0105" />
     </GuidSymbol>
 
     <GuidSymbol name="guidCPPCheckPluginMultiProjectCmdSet" value="{a21f0125-e59b-4ac6-8db6-fc01601237d7}">
       <IDSymbol name="MyMultiProjectMenuGroup" value="0x1023" />
-      <IDSymbol name="cmdidCheckProjectsCppcheck" value="0x0100" />
+      <IDSymbol name="cmdidCheckProjectsCppcheck" value="0x0106" />
     </GuidSymbol>
 
     <GuidSymbol name="guidCPPCheckPluginMultiItemCmdSet" value="{6db8495c-52d3-45d8-ba02-09a3938aa893}">
       <IDSymbol name="MyMultiItemMenuGroup" value="0x1023" />
-      <IDSymbol name="cmdidCheckMultiItemCppcheck" value="0x0100" />
+      <IDSymbol name="cmdidCheckMultiItemCppcheck1" value="0x0107" />
     </GuidSymbol>
 
     <GuidSymbol name="guidImages" value="{c0a853da-1933-420e-ac21-cbca10f4542c}" >
@@ -193,7 +193,7 @@
       <IDSymbol name="bmpPicArrows" value="5" />
       <IDSymbol name="bmpPicStrikethrough" value="6" />
     </GuidSymbol>
-    
+
   </Symbols>
 
 </CommandTable>

--- a/CPPCheckPlugin/CPPCheckPluginPackage.cs
+++ b/CPPCheckPlugin/CPPCheckPluginPackage.cs
@@ -508,14 +508,30 @@ namespace VSPackage.CPPCheckPlugin
 
 				case "{8E7B96A8-E33D-11D0-A6D5-00C04FB67F6A}":
 				case VSConstants.ItemTypeGuid.PhysicalFile_string:
-					var codeModel = item.FileCodeModel;
-					if (codeModel != null)
+					if (item.ConfigurationManager != null)
                     {
-                        switch (codeModel.Language)
-                        {
-							case CodeModelLanguageConstants.vsCMLanguageVC:
-								return ProjectItemType.cppFile;
+						try
+						{
+							VCFile vcFile = item.Object as VCFile;
+							VCProject vcProject = item.ContainingProject.Object as VCProject;
+							VCFileConfiguration fileConfig = vcFile.FileConfigurations.Item(vcProject.ActiveConfiguration.Name);
+
+							if (!fileConfig.ExcludedFromBuild)
+							{
+								var codeModel = item.FileCodeModel;
+								if (codeModel != null)
+								{
+									switch (codeModel.Language)
+									{
+										case CodeModelLanguageConstants.vsCMLanguageVC:
+											return ProjectItemType.cppFile;
+									}
+								}
+							}
 						}
+						catch (Exception)
+                        {
+                        }
                     }
 
 					return ProjectItemType.other;

--- a/CPPCheckPlugin/ICodeAnalyzer.cs
+++ b/CPPCheckPlugin/ICodeAnalyzer.cs
@@ -175,7 +175,13 @@ namespace VSPackage.CPPCheckPlugin
 		{
 			_terminateThread = false;
 			foreach (var arguments in _allArguments)
-				startAnalyzerProcess(analyzerExePath, arguments);
+			{
+				// Don't start subsequent processes if we've been requested to cancel.
+				if (!_terminateThread)
+				{
+					startAnalyzerProcess(analyzerExePath, arguments);
+				}
+			}
 		}
 
 		private void startAnalyzerProcess(string analyzerExePath, string arguments)
@@ -204,7 +210,7 @@ namespace VSPackage.CPPCheckPlugin
 				process.OutputDataReceived += new DataReceivedEventHandler(this.analyzerOutputHandler);
 				process.ErrorDataReceived += new DataReceivedEventHandler(this.analyzerOutputHandler);
 
-				_ = CPPCheckPluginPackage.AddTextToOutputWindowAsync("Starting analyzer with arguments: " + arguments + "\n");
+				_ = CPPCheckPluginPackage.AddTextToOutputWindowAsync("Starting analyzer with arguments: \"" + analyzerExePath + "\" " + arguments + "\n");
 
 				var timer = Stopwatch.StartNew();
 				// Start the process.

--- a/CPPCheckPlugin/SourceFile.cs
+++ b/CPPCheckPlugin/SourceFile.cs
@@ -245,6 +245,11 @@ namespace VSPackage.CPPCheckPlugin
 			}
 		}
 
+		public int Count()
+        {
+			return _files.Count;
+        }
+
 		public bool Exists(string filePath)
         {
 			return _files.ContainsKey(filePath);

--- a/CPPCheckPlugin/SourceFile.cs
+++ b/CPPCheckPlugin/SourceFile.cs
@@ -105,7 +105,7 @@ namespace VSPackage.CPPCheckPlugin
 
 		public void addMacro(string macro)
 		{
-			if (!String.IsNullOrEmpty(macro))
+			if (!String.IsNullOrEmpty(macro) && !macro.Equals("\\\"\\\""))
             {
 				_activeMacros.Add(macro);
 			}
@@ -121,7 +121,7 @@ namespace VSPackage.CPPCheckPlugin
 
 		public void addMacroToUndefine(string macro)
 		{
-			if (!String.IsNullOrEmpty(macro))
+			if (!String.IsNullOrEmpty(macro) && !macro.Equals("\\\"\\\""))
 			{
 				_macrosToUndefine.Add(macro);
 			}


### PR DESCRIPTION
Add full project scanning which was both incomplete and broken. It will now correctly identify filetypes, correctly get inherited properties from individual files, project-level and property sheets, and separate out configuration sets to separate instances of cppcheck.